### PR TITLE
devise-migratable module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ test/version_tmp
 tmp
 *.sqlite
 gemfiles/*.lock
+.DS_Store

--- a/lib/devise-encryptable.rb
+++ b/lib/devise-encryptable.rb
@@ -1,1 +1,2 @@
 require "devise/encryptable/encryptable"
+require "devise/migratable/migratable"

--- a/lib/devise/migratable/encryptors/base.rb
+++ b/lib/devise/migratable/encryptors/base.rb
@@ -1,0 +1,27 @@
+module Devise
+    # Implements a way of adding different encryptions.
+    # The class should implement a self.digest method that taks the following params:
+    #   - password
+    #   - stretches: the number of times the encryption will be applied
+    #   - salt: the password salt as defined by devise
+    #   - pepper: Devise config option
+    #
+    module Migratable
+      module Encryptors
+        class Base
+          def self.digest(password, stretches, salt, pepper)
+            raise NotImplementedError
+          end
+  
+          def self.salt(stretches)
+            Devise.friendly_token[0,20]
+          end
+  
+          def self.compare(encrypted_password, password, stretches, salt, pepper)
+            Devise.secure_compare(encrypted_password, digest(password, stretches, salt, pepper))
+          end
+        end
+      end
+    end
+  end
+  

--- a/lib/devise/migratable/encryptors/pbkdf2_sha512.rb
+++ b/lib/devise/migratable/encryptors/pbkdf2_sha512.rb
@@ -1,0 +1,69 @@
+module Devise
+    module Migratable
+      module Encryptors
+        # https://en.wikipedia.org/wiki/PBKDF2
+        # Adapted from https://gitlab.com/gitlab-org/gitlab/-/blob/373f088e755f678478b8dd1627fab908d2641b21/vendor/gems/devise-pbkdf2-encryptable/lib/devise/pbkdf2_encryptable/encryptors/pbkdf2_sha512.rb
+        class Pbkdf2Sha512 < Base
+          STRATEGY = 'pbkdf2-sha512'
+  
+          # since stretches and iterations are part of the hashed pass, so ignore them during comparing
+          def self.compare(encrypted_password, password, _stretches, _salt, pepper)
+            split_digest = self.split_digest(encrypted_password)
+            value_to_test = sha512_checksum(password, split_digest[:stretches], split_digest[:salt], pepper)
+  
+            Devise.secure_compare(split_digest[:checksum], value_to_test)
+          end
+  
+          def self.digest(password, stretches, salt, pepper)
+            checksum = sha512_checksum(password, stretches, salt, pepper)
+  
+            format_hash(STRATEGY, stretches, salt, checksum)
+          end
+  
+          private_class_method def self.sha512_checksum(password, stretches, salt, pepper)
+            hash = OpenSSL::Digest.new('SHA512')
+            pbkdf2_checksum(hash, password, stretches, salt, pepper)
+          end
+  
+          private_class_method def self.pbkdf2_checksum(hash, password, stretches, salt, pepper)
+            OpenSSL::KDF.pbkdf2_hmac(
+              password.to_s,
+              salt: "#{[salt].pack('H*')}#{pepper}",
+              iterations: stretches,
+              hash: hash,
+              length: hash.digest_length
+            ).unpack1('H*')
+          end
+  
+          # Passlib-style hash: $pbkdf2-sha512$rounds$salt$checksum
+          # where salt and checksum are "adapted" Base64 encoded
+          private_class_method def self.format_hash(strategy, stretches, salt, checksum)
+            encoded_salt = passlib_encode64(salt)
+            encoded_checksum = passlib_encode64(checksum)
+  
+            "$#{strategy}$#{stretches}$#{encoded_salt}$#{encoded_checksum}"
+          end
+  
+          private_class_method def self.passlib_encode64(value)
+            Base64.strict_encode64([value].pack('H*')).tr('+', '.').delete('=')
+          end
+  
+          private_class_method def self.passlib_decode64(value)
+            enc = value.tr('.', '+')
+            Base64.decode64(enc).unpack1('H*')
+          end
+  
+          private_class_method def self.split_digest(hash)
+            split_digest = hash.split('$')
+            _, strategy, stretches, salt, checksum = split_digest
+  
+            raise InvalidHash, 'invalid PBKDF2 hash' unless split_digest.length == 5 && strategy.start_with?('pbkdf2-')
+  
+            { strategy: strategy, stretches: stretches.to_i,
+              salt: passlib_decode64(salt), checksum: passlib_decode64(checksum) }
+          end
+        end
+      end
+    end
+  end
+  

--- a/lib/devise/migratable/migratable.rb
+++ b/lib/devise/migratable/migratable.rb
@@ -1,0 +1,22 @@
+module Devise
+  # Used to define the password encryption algorithm.
+  mattr_accessor :encryptor
+  @@encryptor = nil
+
+  mattr_accessor :feature_class
+  @@feature_class = nil
+
+  mattr_accessor :feature_name
+  @@feature_name = nil
+
+  module Migratable
+    module Encryptors
+      InvalidHash = Class.new(StandardError)
+
+      autoload :Base, 'devise/migratable/encryptors/base'
+      autoload :Pbkdf2Sha512, 'devise/migratable/encryptors/pbkdf2_sha512'
+    end
+  end
+end
+
+Devise.add_module(:migratable, model: 'devise/migratable/model')

--- a/lib/devise/migratable/model.rb
+++ b/lib/devise/migratable/model.rb
@@ -1,0 +1,154 @@
+require 'devise/strategies/database_authenticatable'
+
+module Devise
+  module Models
+    # Migratable module adds support to help gradually migrating default devise hashing to
+    # a new encryptor controlled by feature flags. If you start from a new system, or you don't
+    # need to gradually migrate / rollback the process, then you should be using `devise-encrytable`
+    # directly.
+    #
+    # This module requires a new database column `encrypted_password_migrate_to` to store the new hashed
+    # password. So for each password set or validate, it would start storing the new hashed password
+    # in encrypted_password_migrate_to. If feature flag enabled, it would start validating against the
+    # encrypted_password_migrate_to. The goal of this module is to allow us gracefully migrate existing password
+    # hashing with the ability to rollback or turn on and off through feature flags.
+    #
+    # Once all users have passwords hashed in the encrypted_password_migrate_to, you could run a migration
+    # to copy/swap data from encrypted_password_migrate_to to encrypted_password, at the same time, replace
+    # this module with `devise-encrytable`.
+    #
+    # == Options
+    #
+    # Migratable adds the following options to devise_for:
+    #
+    #   * +pepper+: a random string used to provide a more secure hash.
+    #
+    #   * +encryptor+: the encryptor going to be used. By default is nil.
+    #
+    #   * +feature_class+: feature class used to check wether validating password using new encryptor.
+    #
+    #   * +feature_name+: feature name will be passed to feature_class.active?(feature_name, user_model).
+    #
+    # == Examples
+    #    # with feature disabled
+    #    User.find(1).valid_password?('password123')
+    #    #=> returns true/false
+    #    #=> if true will start saving new hashed password to encrypted_password_migrate_to using encryptor
+    #    #=> still using encrypted_password to validate because feature not enabled
+    #
+    #    # with feature enabled
+    #    User.find(1).valid_password?('password123')
+    #    #=> returns true/false
+    #    #=> validate against encrypted_password_migrate_to using encryptor, fallback to old one if encrypted_password_migrate_to not present
+    module Migratable
+      extend ActiveSupport::Concern
+
+      def self.required_fields(_klass)
+        [:encrypted_password_migrate_to]
+      end
+
+      # Generates new password for the new encryptor
+      # generate password of the old one using super
+      def password=(new_password)
+        # everytime we store the new one with the given encryptor
+        self.encrypted_password_migrate_to = generate_digest_for_password(new_password)
+        # this will set the original password to the database, nothing changed
+        super
+      end
+
+      # Validates the password considering the salt.
+      def valid_password?(password)
+        return false if encrypted_password.blank?
+
+        # only if feature enabled? then we do the work here
+        if feature_enabled? && encrypted_password_migrate_to.present?
+          valid_password_using_encryptor?(password)
+        else
+          result = super
+          update_encrypted_password_migrate_to(password) if result && encrypted_password_migrate_to.nil?
+          result
+        end
+      end
+
+      # redefine serializable_hash to prevent encrypted_password_migrate_to leaking
+      def serializable_hash(options = {})
+        options[:except] ||= []
+        options[:except].push(:encrypted_password_migrate_to)
+        super(options)
+      end
+
+      protected
+
+      def update_encrypted_password_migrate_to(password)
+        update_attribute(:encrypted_password_migrate_to, generate_digest_for_password(password))
+      rescue StandardError => e # capture StandardError instead of ActiveRecordError to play safe
+        log_error('Failed to update_attribute encrypted_password_migrate_to', e)
+      end
+
+      def generate_digest_for_password(password)
+        encryptor_class.digest(password,
+                               self.class.stretches,
+                               self.class.password_salt,
+                               self.class.pepper)
+      end
+
+      def feature_enabled?
+        feature_class&.try(:active?, feature_name, self)
+      end
+
+      def valid_password_using_encryptor?(password)
+        encryptor_arguments = [
+          encrypted_password_migrate_to,
+          password,
+          self.class.stretches,
+          self.class.password_salt,
+          self.class.pepper
+        ]
+        encryptor_class.compare(*encryptor_arguments)
+      end
+
+      def log_error(msg, error)
+        try(:logger)&.error("#{msg}: #{error}")
+      end
+
+      def encryptor_class
+        self.class.encryptor_class
+      end
+
+      def feature_class
+        self.class.feature_class
+      end
+
+      def feature_name
+        self.class.feature_name
+      end
+
+      # class method get injected into Devise module
+      module ClassMethods
+        Devise::Models.config(self, :encryptor, :feature_class, :feature_name)
+
+        # Returns the class for the configured encryptor.
+        def encryptor_class
+          @encryptor_class ||= compute_encryptor_class(encryptor)
+        end
+
+        def password_salt
+          encryptor_class.salt(stretches)
+        end
+
+        private
+
+        def compute_encryptor_class(encryptor)
+          case encryptor
+          when :bcrypt
+            raise 'In order to use bcrypt as encryptor, simply remove :encryptable from your devise model'
+          when nil
+            raise 'You need to give an :encryptor as option in order to use :encryptable'
+          else
+            Devise::Migratable::Encryptors.const_get(encryptor.to_s.classify)
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/devise/migratable/encryptors/pbkdf2_sha512_test.rb
+++ b/test/devise/migratable/encryptors/pbkdf2_sha512_test.rb
@@ -1,0 +1,45 @@
+require 'test_helper'
+require 'benchmark'
+
+class Pbkdf2Sha512Test < ActiveSupport::TestCase
+  include Support::Assertions
+  include Support::Factories
+  include Support::Swappers
+
+  STETCHES = 210_000
+  PEPPER = 'thisisasuperlongstringusedontopofsalt'.freeze
+
+  def encrypt_password(admin, pepper = Admin.pepper, stretches = Admin.stretches, encryptor = Admin.encryptor_class)
+    encryptor.digest('123456', stretches, admin.password_salt, pepper)
+  end
+
+  def random_salt
+    Devise::Migratable::Encryptors::Base.salt(STETCHES)
+  end
+
+  test 'digest and compare success' do
+    plain_pass = 'password1'
+    hashed_password = Devise::Migratable::Encryptors::Pbkdf2Sha512.digest(plain_pass, STETCHES, random_salt, PEPPER)
+    assert Devise::Migratable::Encryptors::Pbkdf2Sha512.compare(hashed_password, plain_pass, nil, nil, PEPPER)
+  end
+
+  test 'invalid password hash raise' do
+    plain_pass = 'password1'
+    assert_raise(Devise::Migratable::Encryptors::InvalidHash) do
+      Devise::Migratable::Encryptors::Pbkdf2Sha512.compare('wrongformatpasshash', plain_pass, nil, nil, PEPPER)
+    end
+  end
+
+  test 'wrong password' do
+    plain_pass = 'password1'
+    hashed_password = Devise::Migratable::Encryptors::Pbkdf2Sha512.digest(plain_pass, 210_000, random_salt, PEPPER)
+    refute Devise::Migratable::Encryptors::Pbkdf2Sha512.compare(hashed_password, 'wrongpass', nil, nil, PEPPER)
+  end
+
+  test 'changed pepper will fail password check' do
+    plain_pass = 'password1'
+    hashed_password = Devise::Migratable::Encryptors::Pbkdf2Sha512.digest(plain_pass, 210_000, random_salt, PEPPER)
+    refute Devise::Migratable::Encryptors::Pbkdf2Sha512.compare(hashed_password, plain_pass, nil, nil,
+                                                            'opps, different pepper')
+  end
+end

--- a/test/devise/migratable/model_test.rb
+++ b/test/devise/migratable/model_test.rb
@@ -1,0 +1,187 @@
+require 'test_helper'
+require 'active_model'
+
+class MigratableTest < ActiveSupport::TestCase
+  include Support::Assertions
+  include Support::Factories
+
+  def unconfig_user_model
+    Class.new do
+      include ActiveModel::Serialization
+      include ActiveModel::Model
+      extend ActiveModel::Callbacks
+      include ActiveModel::Validations::Callbacks
+      extend Devise::Models
+      # in order to call update_attribute
+
+      define_model_callbacks :update, only: :after
+
+      devise :database_authenticatable, :migratable
+
+      attr_accessor :encrypted_password, :encrypted_password_migrate_to
+
+      def initialize(encrypted_password: '')
+        self.encrypted_password = encrypted_password
+        super
+      end
+
+      # skip active record layer
+      def update_attribute(_name, value)
+        self.encrypted_password_migrate_to = value
+      end
+
+      # prevent moving salt everytime
+      def self.password_salt
+        'here we go'
+      end
+
+      def attributes
+        { 'encrypted_password' => nil, 'encrypted_password_migrate_to' => nil }
+      end
+    end
+  end
+
+  def configed_user_model
+    Class.new(unconfig_user_model) do
+      devise :database_authenticatable, :migratable, encryptor: :pbkdf2_sha512
+    end
+  end
+
+  def random_password_salt_user_model
+    Class.new(configed_user_model) do
+      def self.password_salt
+        Devise.friendly_token[0, 20]
+      end
+    end
+  end
+
+  def user_model_with_additional_except_list
+    Class.new(configed_user_model) do
+      attr_accessor :phone
+
+      def serializable_hash(options = {})
+        options = options.try(:dup) || {}
+        options[:except] ||= %i[phone]
+        super options
+      end
+
+      def attributes
+        { 'encrypted_password' => nil, 'encrypted_password_migrate_to' => nil, 'phone' => nil }
+      end
+    end
+  end
+
+  def feature_class(active: true)
+    Class.new do
+      define_singleton_method :active? do |_name, _model|
+        active
+      end
+    end
+  end
+
+  def configed_user_model_with_feature(enabled: true)
+    enabled_feature_class = feature_class(active: enabled)
+    Class.new(unconfig_user_model) do
+      devise :database_authenticatable,
+             :migratable,
+             encryptor: :pbkdf2_sha512,
+             feature_class: enabled_feature_class,
+             feature_name: :does_not_matter
+    end
+  end
+
+  def make_user_model_raise_error_when_updating_attribute
+    user_class = configed_user_model
+    Class.new(user_class) do
+      def update_attribute(_name, _value)
+        raise ActiveRecord::ActiveRecordError, 'Can not update attribute somehow'
+      end
+    end
+  end
+
+  test 'should generate salt while setting password' do
+    user = configed_user_model.new
+    user.password = 'password'
+
+    new_encrypted_pass = '$pbkdf2-sha512$1$Hr4A4Ag$CMvUhq6jnDgfYLtLGYlI30t5kDl/enxTd0ATWSuK2NmekdY9osewu3b4KEaAhygMipdeE.9fL0Ur56bnDpQkTQ'
+    assert_equal user.encrypted_password_migrate_to, new_encrypted_pass
+
+    store_old_encrypted_pass = user.encrypted_password
+    assert user.valid_password?('password')
+
+    # now let's creat a new user instance and validate against the old one
+    another_user = configed_user_model.new(encrypted_password: store_old_encrypted_pass)
+    assert another_user.valid_password?('password')
+  end
+
+  test 'should validate against the new password column' do
+    user = configed_user_model_with_feature(enabled: true).new
+    user.password = 'password'
+    # mess around with old one so we ensure it's checking against the new one
+    user.encrypted_password = 'thisonly changes old one'
+    assert user.valid_password?('password')
+  end
+
+  test 'should save new encrypted pass if not exists at the beginning' do
+    user = configed_user_model.new
+    user.password = 'password'
+    # let's nil it
+    user.encrypted_password_migrate_to = nil
+    user.valid_password?('password')
+    # here the new encrypted password should be present
+    refute user.encrypted_password_migrate_to.nil?
+  end
+
+  test "should not save new encrypted password if it's already exists" do
+    user = random_password_salt_user_model.new
+    user.password = 'password'
+    # check
+    user.encrypted_password_migrate_to = nil
+    assert user.valid_password?('password')
+    # now it's set the new one
+    new_encrypted_pass = user.encrypted_password_migrate_to
+    # check validation again
+    assert user.valid_password?('password')
+    # new encrypted pass should not be updated if it's exists
+    assert_equal new_encrypted_pass, user.encrypted_password_migrate_to
+  end
+
+  test 'should not serialize the new encrypted password col' do
+    user = configed_user_model_with_feature(enabled: true).new
+    user.password = 'password'
+    # convert it to json
+    inspect_str = user.inspect
+    refute inspect_str.include?('encrypted_password_migrate_to')
+  end
+
+  test 'should not validate new encrypted password if feature flag is off' do
+    user = configed_user_model_with_feature(enabled: false).new
+    user.password = 'password'
+    # manually set the encrypted_password_migrate_to to a wrong one
+    user.encrypted_password_migrate_to = 'notrightone'
+    assert user.valid_password?('password')
+  end
+
+  test 'should fallback to validating encrypted_password if encrypted_password_migrate_to not present even with feature enabled' do
+    user = configed_user_model_with_feature(enabled: true).new
+    user.password = 'password'
+    # manually set the encrypted_password_migrate_to to empty
+    user.encrypted_password_migrate_to = nil
+    assert user.valid_password?('password')
+  end
+
+  test 'migratable should respect parent model except list' do
+    user = user_model_with_additional_except_list.new
+    user.phone = 'xx-xx-xxxx'
+    inspect_str = user.inspect
+    refute inspect_str.include?('phone')
+  end
+
+  test 'migratable should not raise error when update_attribute failed' do
+    user = make_user_model_raise_error_when_updating_attribute.new
+    user.password = 'password'
+    # nil the encrypted_password_migrate_to column so this will enforce we are calling the update_attribute
+    user.encrypted_password_migrate_to = nil
+    assert user.valid_password?('password')
+  end
+end


### PR DESCRIPTION
## Context:
Create a new devise module focusing on __gradually migrating from default devise pass hashing to the given one__.

This could be in its own gem, but keep it here for now because 1. it's easy to switch to `devise-encrytable` once migration is done; 2. easier to understand the context.

Detailed RFC for rollout plan [here](https://betterup.atlassian.net/wiki/spaces/ET/pages/3064922237/RFC+Migrate+BUAPP+passwords+from+bcrypt+to+PBKDF2#Proposal).


## Usage
```ruby
# in config/initializers/devise.rb

config.encryptor = :pbkdf2_sha512
config.feature_class = Features
config.feature_name = :enable_new_encryptor
```

Generate migration to add the new column:
```ruby
class AddNewEncryptedPasswordColumnForMigration < ActiveRecord::Migration[7.0]
  def change
    add_column :users, : encrypted_password_migrate_to, :string
  end
end
```

## What happened after this?
1. For each user login, we will start saving (during user registration, reset password or login) the pbkdf2_sha512 hashed password in `encrypted_password_migrate_to`.
2. For each `valid_password?` call, we will consult `Features.active?(:enable_new_encryptor, user)`
   a) true -> we will valid_password using column `encrypted_password_migrate_to` and `pbkdf2_sha512`, fallback to old one if new hashed password not exists.
  b) false -> we will keep using existing devise password validation against `encrypted_password`

For more details please see the [rollout plan](https://betterup.atlassian.net/wiki/spaces/ET/pages/3064922237/RFC+Migrate+BUAPP+passwords+from+bcrypt+to+PBKDF2#Proposal)



