### PR TITLE
using update_column instead of update_attribute to avoid callbacks

### DIFF
--- a/lib/devise/migratable/model.rb
+++ b/lib/devise/migratable/model.rb
@@ -80,9 +80,11 @@ module Devise
       protected
 
       def update_encrypted_password_migrate_to(password)
-        update_attribute(:encrypted_password_migrate_to, generate_digest_for_password(password))
+        return if new_record?
+
+        update_column(:encrypted_password_migrate_to, generate_digest_for_password(password))
       rescue StandardError => e # capture StandardError instead of ActiveRecordError to play safe
-        log_error('Failed to update_attribute encrypted_password_migrate_to', e)
+        log_error('Failed to update_column encrypted_password_migrate_to', e)
       end
 
       def generate_digest_for_password(password)


### PR DESCRIPTION
Context:

We are seeing some issues when using `update_attribute` which might be the cause because of all callbacks involved when calling `update_attribute` (which was called when `valid_password?`).

So choose a less intrusive method to update the new hashed password column.

Issues:
https://betterup.atlassian.net/browse/BUAPP-59463

Deep dive updates:

Turns out `update_attribute` are way more "smart/intrusive" than I thought. It will issue `INSERT` command without model level validation when it's a new record. So here we skip update the column at all when it's being used in a context of new record calling `valid_password?`

More context will be added to the [Jira issue](https://betterup.atlassian.net/browse/BUAPP-59463) on the deep dive section.