### PR TITLE
GFSB-1389 validating encrypted_password using given encryptor strategy with fallbacks

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,130 +1,21 @@
 name: Test
 on: [push, pull_request]
+
 jobs:
   test:
-    strategy:
-      fail-fast: false
-      matrix:
-        gemfile:
-          - Gemfile
-          - gemfiles/Gemfile-rails-main
-          - gemfiles/Gemfile-rails-6-1
-          - gemfiles/Gemfile-rails-6-0
-          - gemfiles/Gemfile-rails-5-2
-          - gemfiles/Gemfile-rails-5-1
-          - gemfiles/Gemfile-rails-5-0
-          - gemfiles/Gemfile-rails-4-2
-          - gemfiles/Gemfile-rails-4-1
-        ruby:
-          - '3.1'
-          - '3.0'
-          - '2.7'
-          - '2.6'
-          - '2.5'
-          - '2.4'
-          - '2.3'
-          - '2.2'
-          - '2.1'
-        exclude:
-          - gemfile: Gemfile
-            ruby: '2.6'
-          - gemfile: Gemfile
-            ruby: '2.5'
-          - gemfile: Gemfile
-            ruby: '2.4'
-          - gemfile: Gemfile
-            ruby: '2.3'
-          - gemfile: Gemfile
-            ruby: '2.2'
-          - gemfile: Gemfile
-            ruby: '2.1'
-          - gemfile: gemfiles/Gemfile-rails-main
-            ruby: '2.6'
-          - gemfile: gemfiles/Gemfile-rails-main
-            ruby: '2.5'
-          - gemfile: gemfiles/Gemfile-rails-main
-            ruby: '2.4'
-          - gemfile: gemfiles/Gemfile-rails-main
-            ruby: '2.3'
-          - gemfile: gemfiles/Gemfile-rails-main
-            ruby: '2.2'
-          - gemfile: gemfiles/Gemfile-rails-main
-            ruby: '2.1'
-          - gemfile: gemfiles/Gemfile-rails-6-1
-            ruby: '2.4'
-          - gemfile: gemfiles/Gemfile-rails-6-1
-            ruby: '2.3'
-          - gemfile: gemfiles/Gemfile-rails-6-1
-            ruby: '2.2'
-          - gemfile: gemfiles/Gemfile-rails-6-1
-            ruby: '2.1'
-          - gemfile: gemfiles/Gemfile-rails-6-0
-            ruby: '3.1'
-          - gemfile: gemfiles/Gemfile-rails-6-0
-            ruby: '2.4'
-          - gemfile: gemfiles/Gemfile-rails-6-0
-            ruby: '2.3'
-          - gemfile: gemfiles/Gemfile-rails-6-0
-            ruby: '2.2'
-          - gemfile: gemfiles/Gemfile-rails-6-0
-            ruby: '2.1'
-          - gemfile: gemfiles/Gemfile-rails-5-2
-            ruby: '3.1'
-          - gemfile: gemfiles/Gemfile-rails-5-2
-            ruby: '3.0'
-          - gemfile: gemfiles/Gemfile-rails-5-2
-            ruby: '2.7'
-          - gemfile: gemfiles/Gemfile-rails-5-2
-            ruby: '2.2'
-          - gemfile: gemfiles/Gemfile-rails-5-2
-            ruby: '2.1'
-          - gemfile: gemfiles/Gemfile-rails-5-1
-            ruby: '3.1'
-          - gemfile: gemfiles/Gemfile-rails-5-1
-            ruby: '3.0'
-          - gemfile: gemfiles/Gemfile-rails-5-1
-            ruby: '2.7'
-          - gemfile: gemfiles/Gemfile-rails-5-1
-            ruby: '2.1'
-          - gemfile: gemfiles/Gemfile-rails-5-0
-            ruby: '3.1'
-          - gemfile: gemfiles/Gemfile-rails-5-0
-            ruby: '3.0'
-          - gemfile: gemfiles/Gemfile-rails-5-0
-            ruby: '2.7'
-          - gemfile: gemfiles/Gemfile-rails-5-0
-            ruby: '2.1'
-          - gemfile: gemfiles/Gemfile-rails-4-2
-            ruby: '3.1'
-          - gemfile: gemfiles/Gemfile-rails-4-2
-            ruby: '3.0'
-          - gemfile: gemfiles/Gemfile-rails-4-2
-            ruby: '2.7'
-          - gemfile: gemfiles/Gemfile-rails-4-2
-            ruby: '2.6'
-          - gemfile: gemfiles/Gemfile-rails-4-1
-            ruby: '3.1'
-          - gemfile: gemfiles/Gemfile-rails-4-1
-            ruby: '3.0'
-          - gemfile: gemfiles/Gemfile-rails-4-1
-            ruby: '2.7'
-          - gemfile: gemfiles/Gemfile-rails-4-1
-            ruby: '2.6'
-          - gemfile: gemfiles/Gemfile-rails-4-1
-            ruby: '2.5'
-          - gemfile: gemfiles/Gemfile-rails-4-1
-            ruby: '2.4'
     runs-on: ubuntu-latest
-    env: # $BUNDLE_GEMFILE must be set at the job level, so it is set for all steps
-      BUNDLE_GEMFILE: ${{ matrix.gemfile }}
+    strategy:
+      matrix:
+        ruby-version: ['3.2', '3.1']
+
     steps:
-      - uses: actions/checkout@v2
-      - name: Setup Bundler 1.x for Rails 4.x
-        if: ${{ matrix.gemfile == 'gemfiles/Gemfile-rails-4-1' || matrix.gemfile == 'gemfiles/Gemfile-rails-4-2' }}
-        run: echo "BUNDLER_VERSION=1.17.3" >> $GITHUB_ENV
-      - uses: ruby/setup-ruby@v1
+      - uses: actions/checkout@v3
+      - name: Set up Ruby ${{ matrix.ruby-version }}
+        uses: ruby/setup-ruby@v1
         with:
-          ruby-version: ${{ matrix.ruby }}
-          bundler-cache: true # runs bundle install and caches installed gems automatically
-          bundler: ${{ env.BUNDLER_VERSION || 'latest' }}
-      - run: bundle exec rake
+          ruby-version: ${{ matrix.ruby-version }}
+          bundler-cache: true
+      - name: Install dependencies
+        run: bundle install
+      - name: Run tests
+        run: bundle exec rake

--- a/Gemfile
+++ b/Gemfile
@@ -7,3 +7,5 @@ gem 'rails', '~> 7.0.0'
 gem 'sqlite3'
 
 gem 'mocha', '~> 1.0', require: false
+
+gem 'simplecov', require: false, group: :test

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -83,6 +83,7 @@ GEM
       responders
       warden (~> 1.2.3)
     digest (3.1.0)
+    docile (1.4.0)
     erubi (1.10.0)
     globalid (1.0.0)
       activesupport (>= 5.0)
@@ -154,6 +155,12 @@ GEM
     responders (3.0.1)
       actionpack (>= 5.0)
       railties (>= 5.0)
+    simplecov (0.22.0)
+      docile (~> 1.1)
+      simplecov-html (~> 0.11)
+      simplecov_json_formatter (~> 0.1)
+    simplecov-html (0.12.3)
+    simplecov_json_formatter (0.1.4)
     sqlite3 (1.4.2)
     strscan (3.0.1)
     thor (1.2.1)
@@ -175,6 +182,7 @@ DEPENDENCIES
   devise-encryptable!
   mocha (~> 1.0)
   rails (~> 7.0.0)
+  simplecov
   sqlite3
 
 BUNDLED WITH

--- a/lib/devise/migratable/encryptors/pbkdf2_sha512.rb
+++ b/lib/devise/migratable/encryptors/pbkdf2_sha512.rb
@@ -19,6 +19,13 @@ module Devise
   
             format_hash(STRATEGY, stretches, salt, checksum)
           end
+
+          def self.valid_hash?(pass)
+            split_digest(pass)
+            true
+          rescue StandardError
+            false
+          end
   
           private_class_method def self.sha512_checksum(password, stretches, salt, pepper)
             hash = OpenSSL::Digest.new('SHA512')

--- a/lib/devise/migratable/migratable.rb
+++ b/lib/devise/migratable/migratable.rb
@@ -3,20 +3,20 @@ module Devise
   mattr_accessor :encryptor
   @@encryptor = nil
 
-  # block to be evaluated to determine wether to validate using encryptor
-  mattr_accessor :enable_validation
-  @@enable_validation = nil
+  mattr_accessor :override_existing_password_hash
+  @@override_existing_password_hash = nil
 
-  # Sets enable_validation block
+
+  # Sets override_existing_password_hash block
   #
   #  Devise.setup do |config|
   #
-  #    config.validate_using_encryptor do |user|
-  #      Features.active?(:enable_pbkdf2_validation, user)
+  #    config.override_existing_password_hash_check do |user|
+  #      Features.active?(:override_existing_password_hash_using_encryptor, user)
   #    end
   #  end
-  def self.validate_using_encryptor(&block)
-    @@enable_validation = block
+  def self.override_existing_password_hash_check(&block)
+    @@override_existing_password_hash = block
   end
 
   module Migratable

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,4 +1,5 @@
 ENV["RAILS_ENV"] = "test"
+require 'simplecov'
 require "devise"
 require "devise/version"
 require "active_support/core_ext/module/attribute_accessors"
@@ -12,6 +13,8 @@ require "mocha/setup"
 require 'support/assertions'
 require 'support/factories'
 require 'support/swappers'
+
+SimpleCov.start
 
 if ActiveSupport.respond_to?(:test_order)
   ActiveSupport.test_order = :random


### PR DESCRIPTION
With the current rollout of Pbkdf2 password hashing, we've been validated the new password hashing and validating works (for now us has 4k users migrated to the new password using new column `encrypted_password_migrate_to`).

However, even with the current process, plus mobile apps do not follow the same re-login pattern as the web (they have way longer sessions because of refresh token), so we need to revise to a way so that both bcrypt pass and Pbkdf2 exists in the `encrypted_password` column.

## This PR is to enable 
1. we store Pbkdf2 right into `encrypted_password` column if `bcrypt` validation success during new user/reset/login. 
2. validate `encrypted_password` using either `bcrypt` or `Pbkdf2` strategy. 
3. Feature flag to control whether we store the new `Pbkdf2` password in `encrypted_password` or `encrypted_password_migrate_to`.

## Things to remember:
- we always validate `encrypted_password` column using two strategies without caring about feature flag. Because this would allow us to taking care of both data in our database which we can not rollback.
- feature flag only controls store the `Pbkdf2` in `encrypted_password` or the safe `encrypted_password_migrate_to`. In case things are going terrifically wrong, we can stop bleeding right away.

(I also added code coverage and Github action to run unit tests.)